### PR TITLE
add notebooks for nircam and source_catalog

### DIFF
--- a/general/Create-Source-Catalog.ipynb
+++ b/general/Create-Source-Catalog.ipynb
@@ -1,0 +1,329 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# This example notebook shows how to create a source catalog through the JWST pipeline source_catalog step\n",
+    "\n",
+    "The specifics are done for a NIRCAM Grism direct image, since the catalog is needed to define the source locations in the grism observation so that the spectral bounding boxes for each order can be extracted for each object. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import os\n",
+    "import jwst\n",
+    "import numpy as np\n",
+    "from astropy.io import fits\n",
+    "print(\"Using jwst pipeline version: {}\".format(jwst.__version__))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### I'm going to use a simulated image as an example, the cell below details its file structure\n",
+    "**Make sure that you have set the JWST_NOTEBOOK_DATA environment variable in the terminal from which you started Jupyter Notebook.**\n",
+    "\n",
+    "The data will be read from that directory, and the pipeline should write to the current working directory, avoiding clobbers. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_dir = os.environ['JWST_NOTEBOOK_DATA']\n",
+    "nircam_data= data_dir + 'data/nircam/'\n",
+    "grism_direct_image = nircam_data + 'nircam_grism_direct_image.fits'\n",
+    "fits.info(grism_direct_image)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Let's take a visual look at the image we are using"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from matplotlib import pyplot as plt\n",
+    "dirim = fits.getdata(grism_direct_image, ext=1)\n",
+    "xs,ys=dirim.shape\n",
+    "fig = plt.figure(figsize=(4,4), dpi=150)\n",
+    "ax = fig.add_subplot(1, 1, 1)\n",
+    "ax.set_adjustable('box-forced')\n",
+    "ax.set_title(grism_direct_image.split(\"/\")[-1], fontsize=8)\n",
+    "ax.imshow(dirim, origin='lower', extent=[0,xs,0,ys], vmin=-10, vmax=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Import the catalog creation step from the pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jwst.source_catalog import source_catalog_step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create the step object, it knows how to create the catalog when it's given a data model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc=source_catalog_step.SourceCatalogStep()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### These are the default step parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(sc.spec)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### This step only works on Drizzle products and single drizzle FITS images\n",
+    "You can open the fits image into a datamodel or you can supply the step with the name of the FITS image directly"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Here we'll use a DataModel\n",
+    "from jwst.datamodels import DrizProductModel\n",
+    "dpm=DrizProductModel(grism_direct_image)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.process(dpm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.table import QTable\n",
+    "source_catalog = 'nircam_grism_direct_image_cat.ecsv'  # this name is listed in the output of the process above"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The INFO log suggests that's too many sources, let's see how we did\n",
+    "The catalog cat be read is as an astropy quantities table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catalog = QTable.read(source_catalog,  format='ascii.ecsv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catalog"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Overplot the object detections on our image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.patches as patches\n",
+    "dirim = fits.getdata(grism_direct_image, ext=1)\n",
+    "xs,ys=dirim.shape\n",
+    "fig = plt.figure(figsize=(4,4), dpi=150)\n",
+    "ax.ticklabel_format(useOffset=False)\n",
+    "ax = fig.add_subplot(1, 1, 1)\n",
+    "ax.ticklabel_format(useOffset=False)\n",
+    "ax.set_adjustable('box-forced')\n",
+    "ax.set_title(grism_direct_image.split(\"/\")[-1], fontsize=8)\n",
+    "ax.imshow(dirim, origin='lower', extent=[0,xs,0,ys], vmin=-10, vmax=10)\n",
+    "\n",
+    "# rectangle patches are xmin, ymin, width, height\n",
+    "plist1=[]\n",
+    "for obj in catalog:\n",
+    "    plist1.append(patches.Circle((obj['xcentroid'].value, obj['ycentroid'].value),10))\n",
+    "\n",
+    "for p in plist1:\n",
+    "    ax.add_patch(p)\n",
+    "    \n",
+    "ax.imshow(dirim, origin='lower', extent=[0,xs,0,ys], vmin=-10, vmax=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Looks like we should edit the defaults so that we can restrict the detections to the visible objects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# as a reminder, these are the defaults\n",
+    "print(sc.spec)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The defaults can be changes in the step object directly"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.npixels=20\n",
+    "sc.snr_threshold=5\n",
+    "sc(dpm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read the new table that was created\n",
+    "catalog = QTable.read(source_catalog,  format='ascii.ecsv')\n",
+    "dirim = fits.getdata(grism_direct_image, ext=1)\n",
+    "xs,ys=dirim.shape\n",
+    "fig = plt.figure(figsize=(4,4), dpi=150)\n",
+    "ax.ticklabel_format(useOffset=False)\n",
+    "ax = fig.add_subplot(1, 1, 1)\n",
+    "ax.ticklabel_format(useOffset=False)\n",
+    "ax.set_adjustable('box-forced')\n",
+    "ax.set_title(grism_direct_image.split(\"/\")[-1], fontsize=8)\n",
+    "ax.imshow(dirim, origin='lower', extent=[0,xs,0,ys], vmin=-10, vmax=10)\n",
+    "\n",
+    "# rectangle patches are xmin, ymin, width, height\n",
+    "plist1=[]\n",
+    "for obj in catalog:\n",
+    "    plist1.append(patches.Circle((obj['xcentroid'].value, obj['ycentroid'].value),10))\n",
+    "\n",
+    "for p in plist1:\n",
+    "    ax.add_patch(p)\n",
+    "    \n",
+    "ax.imshow(dirim, origin='lower', extent=[0,xs,0,ys], vmin=-10, vmax=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Not bad!  There were two nearby sources that were not deblended, but we'll leave that for now."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# checkout the final catalog\n",
+    "print(source_catalog)\n",
+    "catalog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/nircam/Using-the-NIRCAM-WFSS-WCS-Object.ipynb
+++ b/nircam/Using-the-NIRCAM-WFSS-WCS-Object.ipynb
@@ -1,0 +1,1313 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Understanding datamodels,  transforms, and the GWCS object created for  NIRCAM Wide Field Slitless Spectroscopy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Simulated NIRCAM data are available from MAST:  http://archive.stsci.edu/jwst/simulations/index.html\n",
+    "\n",
+    "Only first order spectra are visible in most cases. Fainter second order spectra only appear in F322W2 + grism observations due to sources near one edge of the field of view.\n",
+    "https://jwst-docs.stsci.edu/display/JTI/NIRCam+Grisms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import jwst\n",
+    "import asdf\n",
+    "\n",
+    "# transforms and datamodels\n",
+    "from jwst.transforms.models import NIRCAMForwardColumnGrismDispersion, NIRCAMForwardRowGrismDispersion\n",
+    "from jwst.transforms.models import NIRCAMBackwardGrismDispersion\n",
+    "from jwst.datamodels.wcs_ref_models import NIRCAMGrismModel\n",
+    "from jwst.datamodels import image\n",
+    "\n",
+    "# wcs\n",
+    "from jwst import assign_wcs\n",
+    "\n",
+    "# print this out as a visual reminder of what version of the jwst pipeline is being referenced\n",
+    "print(\"Using jwst pipeline version: {}\".format(jwst.__version__))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Make sure that you have set the JWST_NOTEBOOK_DATA environment variable in the terminal from which you started Jupyter Notebook.\n",
+    "\n",
+    "The data will be read from that directory, and the pipeline should write to the current working directory, avoiding clobbers.\n",
+    "If you would like to use your own data just substitute the locations below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "notebook_dir = os.environ['JWST_NOTEBOOK_DATA']\n",
+    "nircam_data = notebook_dir + 'data/nircam/'\n",
+    "\n",
+    "grism_file = nircam_data + 'nircam_grism_dispersed_image.fits'  # this is a row dispersed grism image\n",
+    "direct_file = nircam_data + 'nircam_grism_direct_image.fits'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Examining the grism dispersion model\n",
+    "The following examples are going to be done specific to the Column Grism, but they are valid for the Row grism as well. In fact, since the referece trace image has been made for GRISMR at the end of this notebook you'll see an example using it's full reference file matches.\n",
+    "<table width=\"100%\"><th width=\"100%\" style=\"text-align:left\" bgcolor=\"d9d9d9\"><h2>NIRCAM Column Grism Dispersion</h2></th></table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lets take a closer look at the reference file\n",
+    "Reference files for the JWST pipeline are stored in <a href=\"https://jwst-crds.stsci.edu/\">CRDS</a>.\n",
+    "\n",
+    "For NIRCAM, the specwcs reference files can be found by browsing to nircam->specwcs on the page linked above"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# You can specify your own reference file, this is one that is also available from CRDS\n",
+    "specwcs = nircam_data + 'jwst_nircam_specwcs_0011.asdf'  # this is a GRISMC reference file\n",
+    "\n",
+    "# open the file into it's datamodel, this can be done by giving the datamodel the filename directly\n",
+    "# We can save some of the items to local variables for easy reference using syntax like this:\n",
+    "with NIRCAMGrismModel(specwcs) as f:\n",
+    "    displ = f.displ\n",
+    "    dispx = f.dispx\n",
+    "    dispy = f.dispy\n",
+    "    invdispx = f.invdispx\n",
+    "    invdispy = f.invdispy\n",
+    "    invdispl = f.invdispl\n",
+    "    orders = f.orders"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# f is the pointer to the file object and it still exists; and there is some history information that we can look at:\n",
+    "f.history"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### There's a link the the 'homepage' in the description, this repository contains the software, `nircam_reftools.py` that was used to create the reference file.\n",
+    "Currently, if you look at that repository, you'll notice that the software was restructured and the functions for making the grism reference files were moved to their own module, this will be reflected in the history of that software is used to make a new reference file for delivery"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# what type of reference file is it?\n",
+    "f.reftype"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Not sure what's in the object? You can always look at the full instance \n",
+    "f.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### if you're creating a new reference file, it's useful to check it by using validate(), this will validate the correctness of the reference object against the schema that specifies what it should contain before writing\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f.validate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### what happens if we try and change orders from a list of numbers to a string?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f['orders'] = 'wrong'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### compared to what happens if we retain the expected data type but still change the data:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f['orders'] = [1,2,3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### this time it should be happy and return no error, because orders is allowed to be a list of numbers\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f.validate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a transform model\n",
+    "We've just looked at the reference file that will support the GWCS model, it contains the building blocks that the full GWCS will need. \n",
+    "\n",
+    "There are several transform models that support NIRCAM:\n",
+    "* NIRCAMForwardColumnGrismDispersion --> this relates to the Column dispersed grism, it moves inputs in the grism frame to the direct image frame\n",
+    "* NIRCAMForwardRowGrismDispersion --> this relates to the Row dispersed grism, it moves inputs in the grism frame frame to the direct image frame\n",
+    "* NIRCAMBackwardGrismDispersion --> this relates to either Row or Column dispersed grisms, it moves inputs in the direct image frame to the grism frame\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Hit enter here for the full explanation of the model inputs, the same can be done for the other models\n",
+    "\n",
+    "press the 'x' that appears in the upper right of the box to close the information blurb\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NIRCAMForwardColumnGrismDispersion?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### We'll create the model by giving it the expected inputs from the reference file we read in above\n",
+    "We already know the from the reference data that it should be used to instantiate the column dispersed grism model from NIRCAM module A:\n",
+    "\n",
+    "`'instrument': {'module': 'A', 'name': 'NIRCAM', 'pupil': 'GRISMC'}`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model=NIRCAMForwardColumnGrismDispersion(orders, displ, dispx, invdispy)\n",
+    "back=NIRCAMBackwardGrismDispersion(orders, invdispl, dispx, dispy)\n",
+    "\n",
+    "# The inverse transform can be added to the model so that one model object can be used to tranform in both directions\n",
+    "model.inverse = back"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.orders  # these are the spectral orders with which the model can be used "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### What are the inputs that this model expects?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# model should accept (x, y, x0, y0, order)\n",
+    "model.inputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<strong>The default direction of the model is forwards, from the grism frame to the direct image frame. So here, the inputs relate to:</strong>\n",
+    "\n",
+    "- x: the x-pixel location in the grism image\n",
+    "- y: the y-pixel location in the grism image\n",
+    "- x0: the source object x-location in the direct image\n",
+    "- y0: the source object y-location in the direct image\n",
+    "- order: the spectral order of concern"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### What are the outputs that this model gives?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# and the model should return (x, y, wavelength, spectral order)\n",
+    "model.outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<strong> The ouputs here are in the detector direct image reference frame</strong>\n",
+    "- x: the x-pixel location of the source object in the direct image\n",
+    "- y: the y-pixel location of the source object in the direct image\n",
+    "- wavelength: the wavelength of the corresponding pixel in the grism image\n",
+    "- order: the spectral order the information pertains to\n",
+    "\n",
+    "This information allows the model to properly pass and translate image <-> dispsersed image <-> image\n",
+    "\n",
+    "<strong>You can see the relation a little better by also looking at the inputs and outputs to the inverse model:</strong>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# direct image frame ->  grism image frame\n",
+    "model.inverse.inputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# grism image frame -> direct image frame\n",
+    "model.inverse.outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Does the model have a name associated with it?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Now for something even more specific....\n",
+    "The WFSS models contain transforms related to x, y and wavelength\n",
+    "\n",
+    "The reference file stores list of models that are valid for each spectral order or element.\n",
+    "\n",
+    "What the following is telling you is that the first order is contained in the zero index of the model list. This is true for any any model list in the reference file; xmodels, ymodels or lmodels.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is used internally to grab the correct transform based on spectral order\n",
+    "model._order_mapping  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### What do the orders and polynomials that we see actually relate to?\n",
+    "The pipeline documentation for the `specwcs` reference files used during the `assign_wcs` step can be found here:\n",
+    "\n",
+    "https://jwst-pipeline.readthedocs.io/en/latest/jwst/assign_wcs/reference_files.html\n",
+    "\n",
+    "For NIRCAM GRISM and TSGRIM modes the specwcs file is in ASDF format with the following members:\n",
+    "\n",
+    "- **displ**:\tcontains the wavelength-dispersion models\n",
+    "- **dispx**:\tcontains the x-dispersion models\n",
+    "- **dispy**:\tcontains the y-dispersion models\n",
+    "- **invdispx**:\tcontains the inverse x-dispersion models\n",
+    "- **invdispy**:\tcontains the inverse y-dispersion models\n",
+    "- **invdispl**:\tcontains the inverse wavelength-dispersion transform models\n",
+    "- **orders**:\ta list of order numbers that the models relate to, in the same order as the models\n",
+    "\n",
+    "\"models\" above are actual `astropy.modeling` models. The `asdf` format allows transforms to be saved to file and recreated on load."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For example, lets look at the wavelength transform models, you should see two models in this list, one for each order\n",
+    "model.xmodels "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### We can see that both orders take the form of a Polynomial 1D, and if you look closer you'll notice that they are unitary because GRISMC disperses in y.\n",
+    "\n",
+    "Lets look at the ymodels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.ymodels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.lmodels  # the wavelength relations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can read more about the Polynomial1D model here: http://docs.astropy.org/en/stable/api/astropy.modeling.polynomial.Polynomial1D.html"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Now, if I just wanted to use these models by themselves I could, but for the WFSS modes they are really meant to work together."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.lmodels[0].inputs  # yah, it says x, it basically just wants one value, this is a linear model in x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.lmodels[0].outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### We can execute the model by giving it an input value:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.lmodels[0](1.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The results should be zero because this is the column model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    " model.xmodels[0](10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### This calculation should yield a non-zero result:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.ymodels[0](10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Some of the models gave us a number, what do they mean?\n",
+    "Here's a longer explanation of the models used in the WFSS modes:\n",
+    "\n",
+    "The models originate from a history of slitless spectroscopy for HST, in packages such as <a href=\"http://axe-info.stsci.edu/extract_calibrate\">aXe</a> and <a href=\"https://github.com/gbrammer/grizli\">Grizli</a>. They have been reformulated for use with JWST, the details of which can be found in this document: http://www.stsci.edu/hst/wfc3/documents/ISRs/WFC3-2017-01.pdf  as well as the code here: https://github.com/npirzkal/GRISMCONF\n",
+    "\n",
+    "\n",
+    "For example, the `lmodel` above accepts a wavelength as input, and returns the normalized location along the trace for that wavelength. This can then be used as input into the xmodel and ymodel to find the exact pixel location of that wavelength, knowing the starting (x0,y0) location of the source object from the direct image associated with the dispersed image. This interaction is what the large GWCS model that is created using the reference file information is helping to facilitate.\n",
+    "\n",
+    "### Let's step through a more detailed example of how this works, we're still just using the pieces we've already examined to this point. Afterwards, we'll create the full GWCS model and show the same procedure, this time the model will translate all the way through to world coordinates.\n",
+    "We'll use the Backwards transform, going from an object position taken from the direct image to the pixel location of a specific wavelength associated with that object\n",
+    "\n",
+    "#### Given pixel location (110,110) in the dispersed image that relates to pixel in the direct image at (100,100) for the first order, what is the wavelength? "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (x, y, x0, y0, order) --> (x0, y0, lam, order)\n",
+    "x0, y0, wavelength, order = model(100, 100, 110, 110, 1)\n",
+    "print(x0, y0, wavelength, order)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Why does the user need to input the coordinates of the object in the direct image?**\n",
+    "This was done for two reasons:\n",
+    "- the user may want to specify directly the object they think the pixel in the dispersed image is associated with in the direct image\n",
+    "- the `extract_1d` code that the pipeline uses works by asking for the wavelength of the pixel in the grism image and looping over pixels. By the time we get to this point for the WFSS pipelines, the code is using cutouts specific to the source and order, the position of the source in full frame coordinates, and the spectral order of the cutout is carried through the process, so it merely asks \"for each dispersed image pixel, what's the wavelegth\"\n",
+    "\n",
+    "#### what about using that information to go the other direction?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (x0, y0, lam, order) --> (x, y, x0, y0, order)?\n",
+    "model.inverse.inputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x, y, x0, y0, order = model.inverse(x0, y0, wavelength, order)\n",
+    "print(x, y, x0, y0, order)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*One thing to note above, the x-location in the output is somewhat arbitrary because the dispersion is along the column and the user can choose the x-width to use, the location of the x-pixel on input is returned for reference.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Now we'll contruct the full transform chain by hand, this is what the full transform model's evaluate() function is doing with the model inputs from the reference file inside the pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# REM\n",
+    "print(order, wavelength, x0, y0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# this combination will translate from the direct image to the dispersed image, what is defined as the backwards direction\n",
+    "iorder = model._order_mapping[int(order)]\n",
+    "t = model.inverse.lmodels[iorder](float(wavelength))\n",
+    "dx = model.inverse.xmodels[iorder](float(t))\n",
+    "dy = model.inverse.ymodels[iorder](float(t))\n",
+    "print(x0+dx, y0+dy, x0, y0, order)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# this combination will translate from the dispersed image to the direct image, the forwards direction\n",
+    "x = 100.\n",
+    "y = 100.\n",
+    "x0 = 110.\n",
+    "y0 = 110.\n",
+    "t = model.ymodels[iorder](y-y0)\n",
+    "dx = model.xmodels[iorder](t)\n",
+    "wavelength = model.lmodels[iorder](t)\n",
+    "\n",
+    "print(x0+dx, y0, wavelength, order)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Now that we've gone over how the models work, we can create our larger model chain that will form the GWCS object and translate all the way to the sky coordinate frame\n",
+    "\n",
+    "First we'll import the modules we need:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gwcs.coordinate_frames as cf\n",
+    "from astropy import units as u\n",
+    "from astropy import coordinates as coord"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Now we'll create the grism detector frame using `coordinate_frames`, the reference frame has units of pixels since it represents a detector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdetector = cf.Frame2D(name='grism_detector',\n",
+    "                       axes_order=(0, 1),\n",
+    "                       unit=(u.pix, u.pix))\n",
+    "gdetector"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Now we need to create the transform model that takes us from the direct image pixel location to the sky coordinate frame\n",
+    "For the NIRCAM WFSS modes, this goes through the imaging wcs pipeline. The pipeline knows to use the information from the dispersed exposure, including the filter element that was used, to get the correct distortion solution. \n",
+    "\n",
+    "In order to demonstrate use of the modules outside of STPIPE, I'm going to call the `jwst.assign_wcs` function directly to create the wcs model I need.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jwst.assign_wcs import nircam"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# open up the grism image, this will be fed to the module for reference\n",
+    "grism_image = image.ImageModel(grism_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grism_image.meta.instrument.filter, grism_image.meta.instrument.pupil, grism_image.meta.instrument.detector,grism_image.meta.exposure.type\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### You'll notice I'm using a row dispersed grism image here. There are reference files which are independent of the grism, this will only be important at the end of this notebook when we call the full `assign_wcs` on the image because it will use a different `specwcs` reference file. Most of the examples above worked with the GRISMC `specwcs` reference file and the non-grism dependent reference files."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reference file types and retrieval\n",
+    "\n",
+    "The module will need some reference file information. CRDS returns different reference file types for NRC_IMAGE and NRC_GRISM, we need the imaging mode reference files for part of the grism pipeline. We've told CRDS to assign the same distortion file to both EXP_TYPES so they should match."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create the step object\n",
+    "assign_wcs_step = assign_wcs.AssignWcsStep()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get reference files we need from CRDS\n",
+    "distortion = assign_wcs_step.get_reference_file(grism_image, 'distortion')  # distortion is independent of grism\n",
+    "wavelengthrange = assign_wcs_step.get_reference_file(grism_image,'wavelengthrange')  # independent of grism\n",
+    "specwcs = specwcs  # use our grismc local reference file \n",
+    "print(\"Reference files for:\\nspecwcs: {}\\nwavelengthrange: {}\\ndistortion: {}\".format(specwcs, wavelengthrange, distortion))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### we'll use the CRDS reference files, except for specwcs, where we'll use our example file.\n",
+    "\n",
+    "I've only populated some of the reference files because those are the only ones we need for WFSS. When testing locally, you can specify any reference filename here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reference_file_names = {'camera': 'N/A',\n",
+    " 'collimator': 'N/A',\n",
+    " 'disperser': 'N/A',\n",
+    " 'distortion': distortion,\n",
+    " 'filteroffset': 'N/A',\n",
+    " 'fore': 'N/A',\n",
+    " 'fpa': 'N/A',\n",
+    " 'ifufore': 'N/A',\n",
+    " 'ifupost': 'N/A',\n",
+    " 'ifuslicer': 'N/A',\n",
+    " 'msa': 'N/A',\n",
+    " 'ote': 'N/A',\n",
+    " 'regions': 'N/A',\n",
+    " 'specwcs': specwcs,\n",
+    " 'wavelengthrange': wavelengthrange}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_pipeline=nircam.imaging(grism_image, reference_file_names)\n",
+    "image_pipeline "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# there should be 3 models that are returned in this list\n",
+    "for m in image_pipeline:\n",
+    "    print(\"model: {}\\n\\n\".format(m))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### We need to insert the models in the correct places, so lets take note of the celestial frame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# keep the world reference frame which should be at the end\n",
+    "world = image_pipeline.pop()\n",
+    "world"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Next, we need to make sure ra, dec, wavelength, and the spectral order get passed through the backwards transforms and are returned from the forwards transforms. To do this, we're going to deconstruct the imaging pipeline and add it to our grism pipeline.\n",
+    "\n",
+    "These modules will help us:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.modeling.models import Scale, Identity, Mapping, Const1D"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### GWCS will accept a chain of (reference frame, transform) tuples, so we'll create the first one, for the grism detector reference frame here. This is the model you saw earlier that moved coordinates from the dispersed image to the direct image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grism_pipeline = [(gdetector, model)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# deconstruct the imaging pipeline and append to the grism pipeline\n",
+    "imagepipe = []\n",
+    "for cframe, trans in image_pipeline:\n",
+    "    trans = trans & (Identity(2))\n",
+    "    imagepipe.append((cframe, trans))\n",
+    "imagepipe.append((world))\n",
+    "grism_pipeline.extend(imagepipe)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This should show there are 4 models in the chain\n",
+    "for m in grism_pipeline:\n",
+    "    print(\"model: {}\\n\\n\".format(m))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Now we can create the full GWCS model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gwcs.wcs import WCS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grism_wcs = WCS(grism_pipeline)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The GWCS model we now have is set up to translate from the dispersed image, to the direct image, to the sky"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grism_wcs.input_frame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grism_wcs.output_frame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grism_wcs.available_frames"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Let's try out our new complete model and make sure it returns the same results as we found previously"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# REM\n",
+    "print(x0, y0, wavelength, order)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grism_wcs(100,100,110,110,1)  # should return (ra, dec, wavelength, order)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The GWCS object allows us to extract sets of transforms, let grab the grism-->direct image transform so we can make a direct comparison with previous results that only had the pixel->pixel translation models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g2d = grism_wcs.get_transform('grism_detector','detector')  # forwards"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g2d(100,100,110,110,1)  # forwards"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g2d.inverse(110.0, 110.0, 3.9269599999722775, 1.0)  # backwards"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### We can pull the transform that goes from the sky --> direct image reference frame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w2d = grism_wcs.get_transform('world','detector')  # this is part of the backwards transform"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pick starting values \n",
+    "ra = -0.04476397838420304  # deg\n",
+    "dec = 0.14901165082101248  # deg\n",
+    "wave = 1.0\n",
+    "order = 1.0\n",
+    "x0, y0, wave, order = w2d(ra, dec, wave, order)\n",
+    "print(x0, y0, wave, order)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Do the values roundtrip?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d2w = grism_wcs.get_transform('detector','world')\n",
+    "n_ra, n_dec, n_wave, n_order = d2w(x0, y0, wave, order)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"differences:\\nra: {}\\ndec: {}\\nwave: {}\\norder: {}\".format(ra-n_ra, dec-n_dec, wave-n_wave, order-n_order))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### If the differences are not zero, there there is something going on with either:\n",
+    "* the models that translate from the imaging detector pixels, through the distortion solution and the telescope pointing to the sky\n",
+    "* the values in the header of the image that was used for the example\n",
+    "* the reference files in use"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Now let's tie everything together and use the pipeline to assign a WCS to a grism image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jwst.assign_wcs.assign_wcs import load_wcs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grism_image = image.ImageModel(grism_file)\n",
+    "grism_image.meta.instrument.filter, grism_image.meta.instrument.pupil, grism_image.meta.instrument.detector,grism_image.meta.exposure.type\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This time we'll get all correct reference files from CRDS\n",
+    "distortion = assign_wcs_step.get_reference_file(grism_image, 'distortion')  # distortion is independent of grism\n",
+    "wavelengthrange = assign_wcs_step.get_reference_file(grism_image,'wavelengthrange')  # independent of grism\n",
+    "specwcs = assign_wcs_step.get_reference_file(grism_image,'specwcs')  # we should see the other reference file for GRISMR now\n",
+    "reference_file_names['specwcs'] = specwcs\n",
+    "reference_file_names['wavelengthrange'] = wavelengthrange\n",
+    "reference_file_names['distortion'] = distortion\n",
+    "reference_file_names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doesitblend = load_wcs(grism_image, reference_file_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# It blends!\n",
+    "doesitblend.meta.wcs(100,100,110,110,1)  # inputs of x,y,x0,y0,order"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doesitblend.meta.wcs.available_frames"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Now we'll fake out the GRISM reference in our test image so you can see the comparative results from the column grism"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grism_image.meta.instrument.pupil = 'GRISMC'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "distortion = assign_wcs_step.get_reference_file(grism_image, 'distortion')  # distortion is independent of grism\n",
+    "wavelengthrange = assign_wcs_step.get_reference_file(grism_image,'wavelengthrange')  # independent of grism\n",
+    "specwcs = assign_wcs_step.get_reference_file(grism_image,'specwcs')  # now the GRISMC reference file should show up again\n",
+    "reference_file_names['specwcs'] = specwcs  \n",
+    "reference_file_names['wavelengthrange'] = wavelengthrange\n",
+    "reference_file_names['distortion'] = distortion\n",
+    "reference_file_names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doesitblend = load_wcs(grism_image, reference_file_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# It blends!\n",
+    "ra, dec, wave, order = doesitblend.meta.wcs(100,100,110,110,1)  # inputs of x,y,x0,y0,order\n",
+    "print(ra, dec, wave, order )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inverse = doesitblend.meta.wcs.get_transform(\"world\",\"grism_detector\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inverse(ra, dec, wave, order)  # outputs of x, y, x0, y0, order"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Almost, you can see how far off the rountrip is now in pixel values, where above we showed the difference in ra/dec values in the sky frame"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Here's a programmatic look at the full GWCS object and transforms it contains"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doesitblend.meta.wcs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Finally, wan't to save the image with the full GWCS to a new file?\n",
+    "I'm saving this to a filename that reminds us we messed with the actual grism specification."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doesitblend.write('nircam_bad_grism_spec.fits')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Want to make sure it's all really still there?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check_image = image.ImageModel('./nircam_bad_grism_spec.fits')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check_image.meta.wcs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
* nircam wfss assign_wcs example: This goes through the steps of creating the GWCS object for NIRCAM WFSS modes, including explanations of the transforms, reference files, datamodels and construction and use of the models and GWCS object

* source_catalog example: a simple example of running the source_catalog step on an image including how to change source detection parameters