### PR TITLE
added engdb example notebook

### DIFF
--- a/general/engdb_plots.ipynb
+++ b/general/engdb_plots.ipynb
@@ -1,0 +1,189 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example of plotting telemetry mnemonics from the EDB\n",
+    "\n",
+    "This is a very simple example using Matplotlib to display the results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from jwst.lib.engdb_tools import ENGDB_Service"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Library"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def engplot(mnemonic, stime='2016-01-01', etime='2016-12-31'):\n",
+    "    values = edb.get_values(mnemonic, stime, etime, include_obstime=True, zip=False)\n",
+    "    dt = list(pd.to_datetime([o.unix for o in values.obstime], unit='s'))\n",
+    "    df = {\n",
+    "        'obstime': dt,\n",
+    "        'value': values.value\n",
+    "    }\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Main"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup access to the engineering DB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "edb = ENGDB_Service()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get the list of mnemonics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mnemonics = [m['TlmMnemonic'] for m in edb.get_meta()['TlmMnemonics']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# how many are available\n",
+    "len(mnemonics)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# some example names which have to do with temperature\n",
+    "[n for n in mnemonics if 'TEMP' in n]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize the plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = engplot('IGDP_NRC_FA_ACE1_SCTEMP')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from matplotlib import pyplot as plt\n",
+    "plt.rcParams['xtick.labelsize'] = 8\n",
+    "plt.rcParams['figure.figsize']=(10,8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(df['obstime'], df['value'],'.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  },
+  "widgets": {
+   "state": {
+    "b45f5ee1a2254171bbf774bb71550308": {
+     "views": [
+      {
+       "cell_index": 17
+      }
+     ]
+    }
+   },
+   "version": "1.2.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
This adds a very simple example for pulling mnemonics from the ENGDB. I started with an older notebook that @stscieisenhamer had and replaced the bokeh plots with a simple matplotlib, since bokeh had deprecated a bunch of things.